### PR TITLE
Fix TypeScript import for Node16 module resolution mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "types": "./types/index.d.ts",
   "exports": {
+    "types": "./types/index.d.ts",
     "import": "./esm/index.js",
     "require": "./cjs/index.js",
     "default": "./esm/index.js"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "ava"
   },
   "devDependencies": {
-    "@types/node": "^18.13.0",
+    "@types/node": "^18.15.0",
     "ava": "^5.2.0",
     "json": "^11.0.0",
     "ts-node": "^10.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,8 +2,8 @@ lockfileVersion: '6.0'
 
 devDependencies:
   '@types/node':
-    specifier: ^18.13.0
-    version: 18.13.0
+    specifier: ^18.15.0
+    version: 18.19.10
   ava:
     specifier: ^5.2.0
     version: 5.2.0
@@ -12,7 +12,7 @@ devDependencies:
     version: 11.0.0
   ts-node:
     specifier: ^10.9.1
-    version: 10.9.1(@types/node@18.13.0)(typescript@4.9.5)
+    version: 10.9.1(@types/node@18.19.10)(typescript@4.9.5)
   typescript:
     specifier: ^4.9.3
     version: 4.9.5
@@ -79,8 +79,10 @@ packages:
     resolution: {integrity: sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==}
     dev: true
 
-  /@types/node@18.13.0:
-    resolution: {integrity: sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==}
+  /@types/node@18.19.10:
+    resolution: {integrity: sha512-IZD8kAM02AW1HRDTPOlz3npFava678pr8Ie9Vp8uRhBROXAv8MXT2pCnGZZAKYdromsNQLHQcfWQ6EOatVLtqA==}
+    dependencies:
+      undici-types: 5.26.5
     dev: true
 
   /acorn-walk@8.2.0:
@@ -1014,7 +1016,7 @@ packages:
       is-number: 7.0.0
     dev: true
 
-  /ts-node@10.9.1(@types/node@18.13.0)(typescript@4.9.5):
+  /ts-node@10.9.1(@types/node@18.19.10)(typescript@4.9.5):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -1033,7 +1035,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
-      '@types/node': 18.13.0
+      '@types/node': 18.19.10
       acorn: 8.8.2
       acorn-walk: 8.2.0
       arg: 4.1.3
@@ -1054,6 +1056,10 @@ packages:
     resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
     engines: {node: '>=4.2.0'}
     hasBin: true
+    dev: true
+
+  /undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
     dev: true
 
   /v8-compile-cache-lib@3.0.1:

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,13 @@ import { pngInfo, PngInfoOptions, PngInfoResponse } from './sdapi/pngInfo.js'
 import { txt2img, Txt2ImgOptions, Txt2ImgResponse } from './sdapi/txt2img.js'
 export * from './types.js'
 
-type Props = {
+export {
+    Img2ImgOptions, Img2ImgResponse,
+    PngInfoOptions, PngInfoResponse,
+    Txt2ImgOptions, Txt2ImgResponse,
+}
+
+export type ClientProps = {
   apiUrl?: string
 }
 
@@ -14,7 +20,7 @@ export type Client = {
   txt2img: (options: Txt2ImgOptions) => Promise<Txt2ImgResponse>
 }
 
-const sdwebui = (props?: Props): Client => {
+const sdwebui = (props?: ClientProps): Client => {
   const apiUrl = props?.apiUrl || 'http://localhost:7860'
 
   return {

--- a/src/sdapi/img2img.ts
+++ b/src/sdapi/img2img.ts
@@ -64,7 +64,6 @@ export const img2img = async (
     endpoint = '/controlnet/img2img'
   }
 
-  /* @ts-ignore */
   const result = await fetch(`${apiUrl}${endpoint}`, {
     method: 'POST',
     body: JSON.stringify(body),

--- a/src/sdapi/pngInfo.ts
+++ b/src/sdapi/pngInfo.ts
@@ -23,7 +23,6 @@ export const pngInfo = async (
     image: options.imageData,
   }
 
-  /* @ts-ignore */
   const result = await fetch(`${apiUrl}/sdapi/v1/png-info`, {
     method: 'POST',
     body: JSON.stringify(body),

--- a/src/sdapi/txt2img.ts
+++ b/src/sdapi/txt2img.ts
@@ -110,7 +110,6 @@ export const txt2img = async (
     endpoint = '/controlnet/txt2img'
   }
 
-  /* @ts-ignore */
   const result = await fetch(`${apiUrl}${endpoint}`, {
     method: 'POST',
     body: JSON.stringify(body),


### PR DESCRIPTION
Closes https://github.com/nerdenough/node-sd-webui/issues/5

For `"moduleResolution": "Node16"` (i.e. native ESM imports), TypeScript requires a `types` field in the `exports` object. This change adds the required field.

Additionally, it exports a few more types, which are very useful in case you actually want to propagate the expected argument types throughout your own adopter code. If unwanted, I can drop the commit again though.

Also fixes the type error related to the `fetch` API.